### PR TITLE
Fix build v1.2.2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -218,6 +218,7 @@ if get_option('config_lspcon_i2c_spi')
 endif
 if get_option('config_realtek_mst_i2c_spi')
   srcs += 'realtek_mst_i2c_spi.c'
+  srcs += 'i2c_helper_linux.c'
   cargs += '-DCONFIG_REALTEK_MST_I2C_SPI=1'
 endif
 if get_option('config_ite_ec')

--- a/meson.build
+++ b/meson.build
@@ -129,98 +129,98 @@ if systems_hwaccess.contains(host_machine.system())
     srcs += files('hwaccess_x86_msr.c', 'hwaccess_x86_io.c')
   endif
 endif
-if config_it8212
+if get_option('config_it8212')
   srcs += 'it8212.c'
   cargs += '-DCONFIG_IT8212=1'
 endif
-if config_linux_mtd
+if get_option('config_linux_mtd')
   srcs += 'linux_mtd.c'
   cargs += '-DCONFIG_LINUX_MTD=1'
 endif
-if config_linux_spi
+if get_option('config_linux_spi')
   srcs += 'linux_spi.c'
   cargs += '-DCONFIG_LINUX_SPI=1'
 endif
-if config_mstarddc_spi
+if get_option('config_mstarddc_spi')
   srcs += 'mstarddc_spi.c'
   cargs += '-DCONFIG_MSTARDDC_SPI=1'
 endif
-if config_nic3com
+if get_option('config_nic3com')
   srcs += 'nic3com.c'
   cargs += '-DCONFIG_NIC3COM=1'
 endif
-if config_nicintel
+if get_option('config_nicintel')
   srcs += 'nicintel.c'
   cargs += '-DCONFIG_NICINTEL=1'
 endif
-if config_nicintel_eeprom
+if get_option('config_nicintel_eeprom')
   srcs += 'nicintel_eeprom.c'
   cargs += '-DCONFIG_NICINTEL_EEPROM=1'
 endif
-if config_nicintel_spi
+if get_option('config_nicintel_spi')
   srcs += 'nicintel_spi.c'
   config_bitbang_spi = true
   cargs += '-DCONFIG_NICINTEL_SPI=1'
 endif
-if config_nicnatsemi
+if get_option('config_nicnatsemi')
   srcs += 'nicnatsemi.c'
   cargs += '-DCONFIG_NICNATSEMI=1'
 endif
-if config_nicrealtek
+if get_option('config_nicrealtek')
   srcs += 'nicrealtek.c'
   cargs += '-DCONFIG_NICREALTEK=1'
 endif
-if config_ogp_spi
+if get_option('config_ogp_spi')
   config_bitbang_spi = true
   srcs += 'ogp_spi.c'
   cargs += '-DCONFIG_OGP_SPI=1'
 endif
-if config_pickit2_spi
+if get_option('config_pickit2_spi')
   srcs += 'pickit2_spi.c'
   cargs += '-DCONFIG_PICKIT2_SPI=1'
 endif
-if config_pony_spi
+if get_option('config_pony_spi')
   srcs += 'pony_spi.c'
   need_serial = true
   config_bitbang_spi = true
   cargs += '-DCONFIG_PONY_SPI=1'
 endif
-if config_rayer_spi
+if get_option('config_rayer_spi')
   srcs += 'rayer_spi.c'
   config_bitbang_spi = true
   need_raw_access = true
   cargs += '-DCONFIG_RAYER_SPI=1'
 endif
-if config_satamv
+if get_option('config_satamv')
   srcs += 'satamv.c'
   cargs += '-DCONFIG_SATAMV=1'
 endif
-if config_satasii
+if get_option('config_satasii')
   srcs += 'satasii.c'
   cargs += '-DCONFIG_SATASII=1'
 endif
-if config_serprog
+if get_option('config_serprog')
   srcs += 'serprog.c'
   cargs += '-DCONFIG_SERPROG=1'
   need_serial = true
 endif
-if config_usbblaster_spi
+if get_option('config_usbblaster_spi')
   srcs += 'usbblaster_spi.c'
   cargs += '-DCONFIG_USBBLASTER_SPI=1'
 endif
-if config_stlinkv3_spi
+if get_option('config_stlinkv3_spi')
   srcs += 'stlinkv3_spi.c'
   cargs += '-DCONFIG_STLINKV3_SPI=1'
 endif
-if config_lspcon_i2c_spi
+if get_option('config_lspcon_i2c_spi')
   srcs += 'lspcon_i2c_spi.c'
   cargs += '-DCONFIG_LSPCON_I2C_SPI=1'
 endif
-if config_realtek_mst_i2c_spi
+if get_option('config_realtek_mst_i2c_spi')
   srcs += 'realtek_mst_i2c_spi.c'
   cargs += '-DCONFIG_REALTEK_MST_I2C_SPI=1'
 endif
-if config_ite_ec
+if get_option('config_ite_ec')
   srcs += 'ite_ec.c'
   cargs += '-DCONFIG_ITE_EC=1'
 endif


### PR DESCRIPTION
Those changes were needed to compile flashrom in Yocto (for DTS). Also I need them to compile flashrom on host PC. I used

```
$ meson --version
0.53.2
$ ninja --version
1.10.0
```

I had two problems.

```
Run-time dependency libftdi1 found: YES 1.4
Did not find CMake 'cmake'
Found CMake: NO
Run-time dependency libjaylink found: NO (tried pkgconfig and cmake)

meson.build:132:3: ERROR: Unknown variable "config_it8212".
```
Resolved by using `get_option`

```
FAILED: flashrom 
cc  -o flashrom 'flashrom@exe/cli_classic.c.o' 'flashrom@exe/cli_common.c.o' 'flashrom@exe/cli_output.c.o' -Wl,--as-needed -Wl,--no-undefined -Wl,--start-group libflashrom.a /usr/lib/x86_64-linux-gnu/libpci.so /usr/lib/x86_64-linux-gnu/libusb-1.0.so /usr/lib/x86_64-linux-gnu/libftdi1.so -Wl,--end-group '-Wl,-rpath,$ORIGIN/' -Wl,-rpath-link,/home/tomzy/flashrom/build/
/usr/bin/ld: libflashrom.a(realtek_mst_i2c_spi.c.o): in function `realtek_mst_i2c_spi_write_data.constprop.0':
realtek_mst_i2c_spi.c:(.text+0x83): undefined reference to `i2c_write'
/usr/bin/ld: libflashrom.a(realtek_mst_i2c_spi.c.o): in function `realtek_mst_i2c_spi_read_register':
realtek_mst_i2c_spi.c:(.text+0x1de): undefined reference to `i2c_read'
/usr/bin/ld: libflashrom.a(realtek_mst_i2c_spi.c.o): in function `realtek_mst_i2c_spi_read':
realtek_mst_i2c_spi.c:(.text+0x779): undefined reference to `i2c_read'
/usr/bin/ld: libflashrom.a(realtek_mst_i2c_spi.c.o): in function `realtek_mst_i2c_spi_shutdown':
realtek_mst_i2c_spi.c:(.text+0x955): undefined reference to `i2c_close'
/usr/bin/ld: libflashrom.a(realtek_mst_i2c_spi.c.o): in function `realtek_mst_i2c_spi_init':
realtek_mst_i2c_spi.c:(.text+0xabe): undefined reference to `i2c_open_from_programmer_params'
collect2: error: ld returned 1 exit status
```

Resolved by adding srcs for `realtek_mst_i2c_spi`