### PR TITLE
flashrom.c: Fail immediately when trying to write/erase wp regions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 /util/ich_descriptors_tool/.obj
 
 target/
+
+subprojects/cmocka-*/
+subprojects/packagecache/

--- a/flashrom.c
+++ b/flashrom.c
@@ -1879,7 +1879,7 @@ int prepare_flash_access(struct flashctx *const flash,
 	}
 
 	if ((write_it || erase_it) && !flash->flags.force) {
-		if(write_protect_check(flash)) {
+		if (write_protect_check(flash)) {
 			msg_cerr("Requested regions are write protected. Aborting.\n");
 			return 1;
 		}

--- a/flashrom.c
+++ b/flashrom.c
@@ -384,6 +384,13 @@ void get_flash_region(const struct flashctx *flash, int addr, struct flash_regio
 	}
 }
 
+struct protected_ranges get_protected_ranges(const struct flashctx *flash) {
+	struct protected_ranges ranges = { 0 };
+	if ((flash->mst->buses_supported & BUS_PROG) && flash->mst->opaque.get_protected_ranges)
+		ranges = flash->mst->opaque.get_protected_ranges();
+	return ranges;
+}
+
 int check_for_unwritable_regions(const struct flashctx *flash, unsigned int start, unsigned int len)
 {
 	struct flash_region region;
@@ -1827,6 +1834,7 @@ static int write_protect_check(struct flashctx *flash) {
 	struct flashrom_wp_cfg *cfg = NULL;
 	const struct romentry *entry = NULL;
 	const struct flashrom_layout *const layout = get_layout(flash);
+	struct protected_ranges ranges = get_protected_ranges(flash);
 
 	if (flashrom_wp_cfg_new(&cfg) == FLASHROM_WP_OK &&
 		flashrom_wp_read_cfg(cfg, flash) == FLASHROM_WP_OK )
@@ -1839,13 +1847,17 @@ static int write_protect_check(struct flashctx *flash) {
 	flashrom_wp_cfg_release(cfg);
 
 	while ((entry = layout_next_included(layout, entry))) {
-		if ((!flash->flags.skip_unwritable_regions &&
-			check_for_unwritable_regions(flash, entry->region.start, entry->region.end - entry->region.start)
-			)
-			||
-			(check_wp && entry->region.start < wp_start + wp_len && wp_start <= entry->region.end))
+		if (!flash->flags.skip_unwritable_regions &&
+			check_for_unwritable_regions(flash, entry->region.start, entry->region.end - entry->region.start))
 		{
 			return -1;
+		}
+		if (check_wp && entry->region.start < wp_start + wp_len && wp_start <= entry->region.end)
+			return -1;
+		for (int i = 0; i < ranges.count; ++i) {
+			struct protected_range prot = ranges.ranges[i];
+			if (prot.write_prot && entry->region.start < prot.base + prot.limit && prot.base <= entry->region.end)
+				return -1;
 		}
 	}
 

--- a/flashrom.c
+++ b/flashrom.c
@@ -1820,6 +1820,38 @@ warn_out:
 	return ret;
 }
 
+static int write_protect_check(struct flashctx *flash) {
+	bool check_wp = false;
+	size_t wp_start, wp_len;
+	enum flashrom_wp_mode mode;
+	struct flashrom_wp_cfg *cfg = NULL;
+	const struct romentry *entry = NULL;
+	const struct flashrom_layout *const layout = get_layout(flash);
+
+	if (flashrom_wp_cfg_new(&cfg) == FLASHROM_WP_OK &&
+		flashrom_wp_read_cfg(cfg, flash) == FLASHROM_WP_OK )
+	{
+		flashrom_wp_get_range(&wp_start, &wp_len, cfg);
+		mode = flashrom_wp_get_mode(cfg);
+		if (mode != FLASHROM_WP_MODE_DISABLED && wp_len != 0)
+			check_wp = true;
+	}
+	flashrom_wp_cfg_release(cfg);
+
+	while ((entry = layout_next_included(layout, entry))) {
+		if ((!flash->flags.skip_unwritable_regions &&
+			check_for_unwritable_regions(flash, entry->region.start, entry->region.end - entry->region.start)
+			)
+			||
+			(check_wp && entry->region.start < wp_start + wp_len && wp_start <= entry->region.end))
+		{
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
 int prepare_flash_access(struct flashctx *const flash,
 			 const bool read_it, const bool write_it,
 			 const bool erase_it, const bool verify_it)
@@ -1832,6 +1864,13 @@ int prepare_flash_access(struct flashctx *const flash,
 	if (layout_sanity_checks(flash)) {
 		msg_cerr("Requested regions can not be handled. Aborting.\n");
 		return 1;
+	}
+
+	if ((write_it || erase_it) && !flash->flags.force) {
+		if(write_protect_check(flash)) {
+			msg_cerr("Requested regions are write protected. Aborting.\n");
+			return 1;
+		}
 	}
 
 	if (map_flash(flash) != 0)

--- a/ichspi.c
+++ b/ichspi.c
@@ -1290,17 +1290,11 @@ struct hwseq_data {
 };
 
 #define MAX_PR_REGISTERS 6
-struct pr_register {
-	enum ich_access_protection level;
-	uint32_t base;
-	uint32_t limit;
+struct protected_range _ranges[MAX_PR_REGISTERS];
+struct protected_ranges ranges = {
+	.count = 0,
+	.ranges = _ranges,
 };
-
-struct _pr_access {
-	uint8_t count;
-	struct pr_register registers[MAX_PR_REGISTERS];
-};
-struct _pr_access pr_access;
 
 static struct hwseq_data *get_hwseq_data_from_context(const struct flashctx *flash)
 {
@@ -1477,22 +1471,15 @@ static void ich_get_region(const struct flashctx *flash, unsigned int addr, stru
 			region->end = limit;
 			region->read_prot  = (level == LOCKED) || (level == READ_PROT);
 			region->write_prot = (level == LOCKED) || (level == WRITE_PROT);
-			if (region->write_prot != true) {
-				for (ssize_t pr = 0; pr < pr_access.count; pr++) {
-					struct pr_register pr_reg = pr_access.registers[pr];
-					if (pr_reg.level == WRITE_PROT &&
-						region->start < pr_reg.base + pr_reg.limit && pr_reg.base <= region->end)
-					{
-						region->write_prot = true;
-						break;
-					}
-				}
-			}
 			break;
 		}
 	}
 
 	region->name = strdup(name);
+}
+
+static struct protected_ranges ich_get_protected_ranges() {
+	return ranges;
 }
 
 /* Given RDID info, return pointer to entry in flashchips[] */
@@ -1978,32 +1965,33 @@ static enum ich_access_protection ich9_handle_region_access(struct fd_region *fd
 #define ICH_PR_PERMS(pr)	(((~((pr) >> PR_RP_OFF) & 1) << 0) | \
 				 ((~((pr) >> PR_WP_OFF) & 1) << 1))
 
-static struct pr_register ich9_handle_pr(const size_t reg_pr0, unsigned int i)
+static enum ich_access_protection ich9_handle_pr(const size_t reg_pr0, unsigned int i, struct protected_range* prot)
 {
 	uint8_t off = reg_pr0 + (i * 4);
 	uint32_t pr = mmio_readl(ich_spibar + off);
 	unsigned int rwperms_idx = ICH_PR_PERMS(pr);
-	struct pr_register pr_reg = {
-		.level = access_perms_to_protection[rwperms_idx],
-		.base = ICH_FREG_BASE(pr),
-		.limit = ICH_FREG_LIMIT(pr),
-	};
+	enum ich_access_protection rwperms = access_perms_to_protection[rwperms_idx];
+
+	prot->base = ICH_FREG_BASE(pr);
+	prot->limit = ICH_FREG_LIMIT(pr);
+	prot->write_prot = rwperms == WRITE_PROT;
+	prot->read_prot = rwperms == READ_PROT || rwperms == LOCKED;
 
 	/* From 5 on we have GPR registers and start from 0 again. */
 	const char *const prefix = i >= 5 ? "G" : "";
 	if (i >= 5)
 		i -= 5;
 
-	if (pr_reg.level == NO_PROT) {
+	if (rwperms == NO_PROT) {
 		msg_pdbg2("0x%02"PRIX8": 0x%08"PRIx32" (%sPR%u is unused)\n", off, pr, prefix, i);
-		return pr_reg;
+		return NO_PROT;
 	}
 
 	msg_pdbg("0x%02"PRIX8": 0x%08"PRIx32" ", off, pr);
 	msg_pwarn("%sPR%u: Warning: 0x%08"PRIx32"-0x%08"PRIx32" is %s.\n", prefix, i, ICH_FREG_BASE(pr),
-		  ICH_FREG_LIMIT(pr), access_names[pr_reg.level]);
+		  ICH_FREG_LIMIT(pr), access_names[rwperms]);
 
-	return pr_reg;
+	return rwperms;
 }
 
 /* Set/Clear the read and write protection enable bits of PR register @i
@@ -2051,6 +2039,7 @@ static const struct opaque_master opaque_master_ich_hwseq = {
 	.read_register	= ich_hwseq_read_status,
 	.write_register	= ich_hwseq_write_status,
 	.get_region	= ich_get_region,
+	.get_protected_ranges = ich_get_protected_ranges,
 	.shutdown	= ich_hwseq_shutdown,
 };
 
@@ -2204,7 +2193,6 @@ static int init_ich_default(const struct programmer_cfg *cfg, void *spibar, enum
 	size_t num_freg, num_pr, reg_pr0;
 	struct hwseq_data hwseq_data = { 0 };
 	init_chipset_properties(&swseq_data, &hwseq_data, &num_freg, &num_pr, &reg_pr0, ich_gen);
-	pr_access.count = num_pr;
 
 	int ret = get_ich_spi_mode_param(cfg, &ich_spi_mode);
 	if (ret)
@@ -2275,12 +2263,12 @@ static int init_ich_default(const struct programmer_cfg *cfg, void *spibar, enum
 	}
 
 	/* Handle PR registers */
+	ranges.count = num_pr;
 	for (i = 0; i < num_pr; i++) {
 		/* if not locked down try to disable PR locks first */
 		if (!ichspi_lock)
 			ich9_set_pr(reg_pr0, i, 0, 0);
-		pr_access.registers[i] = ich9_handle_pr(reg_pr0, i);
-		ich_spi_rw_restricted |= pr_access.registers[i].level;
+		ich_spi_rw_restricted |= ich9_handle_pr(reg_pr0, i, &_ranges[i]);
 	}
 
 	switch (ich_spi_rw_restricted) {

--- a/ichspi.c
+++ b/ichspi.c
@@ -1974,7 +1974,7 @@ static enum ich_access_protection ich9_handle_pr(const size_t reg_pr0, unsigned 
 
 	prot->base = ICH_FREG_BASE(pr);
 	prot->limit = ICH_FREG_LIMIT(pr);
-	prot->write_prot = rwperms == WRITE_PROT;
+	prot->write_prot = (rwperms == WRITE_PROT) || (rwperms == LOCKED);
 	prot->read_prot = (rwperms == READ_PROT) || (rwperms == LOCKED);
 
 	/* From 5 on we have GPR registers and start from 0 again. */

--- a/ichspi.c
+++ b/ichspi.c
@@ -1975,7 +1975,7 @@ static enum ich_access_protection ich9_handle_pr(const size_t reg_pr0, unsigned 
 	prot->base = ICH_FREG_BASE(pr);
 	prot->limit = ICH_FREG_LIMIT(pr);
 	prot->write_prot = rwperms == WRITE_PROT;
-	prot->read_prot = rwperms == READ_PROT || rwperms == LOCKED;
+	prot->read_prot = (rwperms == READ_PROT) || (rwperms == LOCKED);
 
 	/* From 5 on we have GPR registers and start from 0 again. */
 	const char *const prefix = i >= 5 ? "G" : "";

--- a/ichspi.c
+++ b/ichspi.c
@@ -1289,6 +1289,19 @@ struct hwseq_data {
 	struct fd_region fd_regions[MAX_FD_REGIONS];
 };
 
+#define MAX_PR_REGISTERS 6
+struct pr_register {
+	enum ich_access_protection level;
+	uint32_t base;
+	uint32_t limit;
+};
+
+struct _pr_access {
+	uint8_t count;
+	struct pr_register registers[MAX_PR_REGISTERS];
+};
+struct _pr_access pr_access;
+
 static struct hwseq_data *get_hwseq_data_from_context(const struct flashctx *flash)
 {
 	return flash->mst->opaque.data;
@@ -1464,6 +1477,17 @@ static void ich_get_region(const struct flashctx *flash, unsigned int addr, stru
 			region->end = limit;
 			region->read_prot  = (level == LOCKED) || (level == READ_PROT);
 			region->write_prot = (level == LOCKED) || (level == WRITE_PROT);
+			if (region->write_prot != true) {
+				for (ssize_t pr = 0; pr < pr_access.count; pr++) {
+					struct pr_register pr_reg = pr_access.registers[pr];
+					if (pr_reg.level == WRITE_PROT &&
+						region->start < pr_reg.base + pr_reg.limit && pr_reg.base <= region->end)
+					{
+						region->write_prot = true;
+						break;
+					}
+				}
+			}
 			break;
 		}
 	}
@@ -1954,28 +1978,32 @@ static enum ich_access_protection ich9_handle_region_access(struct fd_region *fd
 #define ICH_PR_PERMS(pr)	(((~((pr) >> PR_RP_OFF) & 1) << 0) | \
 				 ((~((pr) >> PR_WP_OFF) & 1) << 1))
 
-static enum ich_access_protection ich9_handle_pr(const size_t reg_pr0, unsigned int i)
+static struct pr_register ich9_handle_pr(const size_t reg_pr0, unsigned int i)
 {
 	uint8_t off = reg_pr0 + (i * 4);
 	uint32_t pr = mmio_readl(ich_spibar + off);
 	unsigned int rwperms_idx = ICH_PR_PERMS(pr);
-	enum ich_access_protection rwperms = access_perms_to_protection[rwperms_idx];
+	struct pr_register pr_reg = {
+		.level = access_perms_to_protection[rwperms_idx],
+		.base = ICH_FREG_BASE(pr),
+		.limit = ICH_FREG_LIMIT(pr),
+	};
 
 	/* From 5 on we have GPR registers and start from 0 again. */
 	const char *const prefix = i >= 5 ? "G" : "";
 	if (i >= 5)
 		i -= 5;
 
-	if (rwperms == NO_PROT) {
+	if (pr_reg.level == NO_PROT) {
 		msg_pdbg2("0x%02"PRIX8": 0x%08"PRIx32" (%sPR%u is unused)\n", off, pr, prefix, i);
-		return NO_PROT;
+		return pr_reg;
 	}
 
 	msg_pdbg("0x%02"PRIX8": 0x%08"PRIx32" ", off, pr);
 	msg_pwarn("%sPR%u: Warning: 0x%08"PRIx32"-0x%08"PRIx32" is %s.\n", prefix, i, ICH_FREG_BASE(pr),
-		  ICH_FREG_LIMIT(pr), access_names[rwperms]);
+		  ICH_FREG_LIMIT(pr), access_names[pr_reg.level]);
 
-	return rwperms;
+	return pr_reg;
 }
 
 /* Set/Clear the read and write protection enable bits of PR register @i
@@ -2176,6 +2204,7 @@ static int init_ich_default(const struct programmer_cfg *cfg, void *spibar, enum
 	size_t num_freg, num_pr, reg_pr0;
 	struct hwseq_data hwseq_data = { 0 };
 	init_chipset_properties(&swseq_data, &hwseq_data, &num_freg, &num_pr, &reg_pr0, ich_gen);
+	pr_access.count = num_pr;
 
 	int ret = get_ich_spi_mode_param(cfg, &ich_spi_mode);
 	if (ret)
@@ -2250,7 +2279,8 @@ static int init_ich_default(const struct programmer_cfg *cfg, void *spibar, enum
 		/* if not locked down try to disable PR locks first */
 		if (!ichspi_lock)
 			ich9_set_pr(reg_pr0, i, 0, 0);
-		ich_spi_rw_restricted |= ich9_handle_pr(reg_pr0, i);
+		pr_access.registers[i] = ich9_handle_pr(reg_pr0, i);
+		ich_spi_rw_restricted |= pr_access.registers[i].level;
 	}
 
 	switch (ich_spi_rw_restricted) {

--- a/include/layout.h
+++ b/include/layout.h
@@ -57,6 +57,18 @@ struct romentry {
 	struct flash_region region;
 };
 
+struct protected_range {
+	uint32_t base;
+	uint32_t limit;
+	bool read_prot;
+	bool write_prot;
+};
+
+struct protected_ranges {
+	int count;
+	const struct protected_range *ranges;
+};
+
 struct flashrom_layout;
 
 struct layout_include_args;
@@ -80,5 +92,6 @@ void prepare_layout_for_extraction(struct flashrom_flashctx *);
 int layout_sanity_checks(const struct flashrom_flashctx *);
 int check_for_unwritable_regions(const struct flashrom_flashctx *flash, unsigned int start, unsigned int len);
 void get_flash_region(const struct flashrom_flashctx *flash, int addr, struct flash_region *region);
+struct protected_ranges get_protected_ranges(const struct flashrom_flashctx *flash);
 
 #endif /* !__LAYOUT_H__ */

--- a/include/programmer.h
+++ b/include/programmer.h
@@ -448,6 +448,7 @@ struct opaque_master {
 	enum flashrom_wp_result (*wp_read_cfg)(struct flashrom_wp_cfg *, struct flashctx *);
 	enum flashrom_wp_result (*wp_get_ranges)(struct flashrom_wp_ranges **, struct flashctx *);
 	void (*get_region)(const struct flashctx *flash, unsigned int addr, struct flash_region *region);
+	struct protected_ranges (*get_protected_ranges)();
 	int (*shutdown)(void *data);
 	void (*delay) (const struct flashctx *flash, unsigned int usecs);
 	void *data;


### PR DESCRIPTION
`write_protect_check` can be deleted and PR0 check will still happen but only one region at a time, so if we write/erase multiple regions (e.g. `-i fd -i bios`) then first region might get written if it is read-write.

In case of e.g. `FREG1: BIOS region (0x00580000-0x00ffffff) is read-write.` & `PR0: Warning: 0x00b00000-0x00ffffff is read-only.` write/erase would still fail even if we tried to flash only unprotected parts of region e.g. `0x00580000-0x00590000`

To force write/erase add `--force` argument. 

meson test:

```
# meson test -C builddir
ninja: Entering directory `/flashrom/builddir'
ninja: no work to do.
1/1 cmocka test flashrom        OK              1.47s

Ok:                 1
Expected Fail:      0
Fail:               0
Unexpected Pass:    0
Skipped:            0
Timeout:            0

Full log written to /flashrom/builddir/meson-logs/testlog.txt
```

---

Tested on Protectli VP6670:

Try to flash whole chip:

```
bash-5.2# flashrom -p internal -w backup.rom
flashrom 1.5.0-devel (git:v1.2-1579-gc50d797f) on Linux 6.6.21-yocto-standard (x86_64)
flashrom is free software, get the source code at https://flashrom.org

coreboot table found at 0x76a14000.
Found chipset "Intel Alder Lake-P".
Enabling flash write... Warning: BIOS region SMM protection is enabled!
Warning: Setting BIOS Control at 0xdc from 0xaa to 0x89 failed.
New value is 0xaa.
SPI Configuration is locked down.
FREG0: Flash Descriptor region (0x00000000-0x00000fff) is read-write.
FREG1: BIOS region (0x00580000-0x00ffffff) is read-write.
FREG2: Management Engine region (0x00001000-0x003aefff) is read-write.
PR0: Warning: 0x00b00000-0x00ffffff is read-only.
At least some flash regions are write protected. For write operations,
you should use a flash layout and include only writable regions. See
manpage for more details.
PROBLEMS, continuing anyway
Found Macronix flash chip "MX25L12805D" (16384 kB, Programmer-specific) on internal.
===
This flash part has status UNTESTED for operations: WP
The test status of this chip may have been updated in the latest development
version of flashrom. If you are running the latest development version,
please email a report to flashrom@flashrom.org if any of the above operations
work correctly for you with this flash chip. Please include the flashrom log
file for all operations you tested (see the man page for details), and mention
which mainboard or programmer you tested in the subject line.
You can also try to follow the instructions here:
https://www.flashrom.org/contrib_howtos/how_to_mark_chip_tested.html
Thanks for your help!
check_for_unwritable_regions: cannot write/erase inside BIOS region (0x580000..0xffffff).
Requested regions are write protected. Aborting.
```

Try to flash protected part:

```
bash-5.2# flashrom -p internal --ifd -i bios -w backup.rom
(...)
Reading ich descriptor... done.
Using region: "bios".
check_for_unwritable_regions: cannot write/erase inside BIOS region (0x580000..0xffffff).
Requested regions are write protected. Aborting.
```

Try to flash unprotected part:

```
bash-5.2# flashrom -p internal --ifd -i fd -w backup.rom
(...)
Reading ich descriptor... done.
Using region: "fd".
Reading old flash chip contents... done.
Erase/write done from 0 to fff
```

---

WP protection checked with dummy programmer:

unprotected part:

```
# builddir/flashrom -p dummy:hwwp=yes,emulate=S25FL128L --wp-enable --wp-range 0x00040000,0x00fc0000 -l <(echo '00000000:0003ffff part1') -i part1 -E
flashrom 1.5.0-devel (git:v1.2-1579-gc50d797f79df) on Linux 6.11.10-300.fc41.x86_64 (x86_64)
flashrom is free software, get the source code at https://flashrom.org

Using region: "part1".
Found Spansion flash chip "S25FL128L" (16384 kB, SPI) on dummy.
===
This flash part has status UNTESTED for operations: WP
The test status of this chip may have been updated in the latest development
version of flashrom. If you are running the latest development version,
please email a report to flashrom@flashrom.org if any of the above operations
work correctly for you with this flash chip. Please include the flashrom log
file for all operations you tested (see the man page for details), and mention
which mainboard or programmer you tested in the subject line.
You can also try to follow the instructions here:
https://www.flashrom.org/contrib_howtos/how_to_mark_chip_tested.html
Thanks for your help!
Enabled hardware protection
Activated protection range: start=0x00040000 length=0x00fc0000 (upper 63/64)
Failed to unlock flash status reg with wp support.
Unsetting lock bit(s) failed.
Erase/write done from 0 to 3ffff
```

Protected part:

```
# builddir/flashrom -p dummy:hwwp=yes,emulate=S25FL128L --wp-enable --wp-range 0x00040000,0x00fc0000 -l <(echo '00000000:0004ffff part1') -i part1 -E
flashrom 1.5.0-devel (git:v1.2-1579-gc50d797f79df) on Linux 6.11.10-300.fc41.x86_64 (x86_64)
flashrom is free software, get the source code at https://flashrom.org

Using region: "part1".
Found Spansion flash chip "S25FL128L" (16384 kB, SPI) on dummy.
===
This flash part has status UNTESTED for operations: WP
The test status of this chip may have been updated in the latest development
version of flashrom. If you are running the latest development version,
please email a report to flashrom@flashrom.org if any of the above operations
work correctly for you with this flash chip. Please include the flashrom log
file for all operations you tested (see the man page for details), and mention
which mainboard or programmer you tested in the subject line.
You can also try to follow the instructions here:
https://www.flashrom.org/contrib_howtos/how_to_mark_chip_tested.html
Thanks for your help!
Enabled hardware protection
Activated protection range: start=0x00040000 length=0x00fc0000 (upper 63/64)
Requested regions are write protected. Aborting.
Your flash chip is in an unknown state.
Please report this to the mailing list at flashrom@flashrom.org or
on IRC (see https://www.flashrom.org/Contact for details), thanks!
```