### PR TITLE
ite_ec.c: change variable name so it doesn't shadow global one

### DIFF
--- a/ite_ec.c
+++ b/ite_ec.c
@@ -710,7 +710,7 @@ static void probe_ite_superio_support(struct ite_ec_data *ctx_data)
 static int ite_ec_init(const struct programmer_cfg *cfg)
 {
 	bool read_success = false;
-	bool force_boardmismatch = false;
+	bool force_boardmismatch_ec = false;
 	struct ite_ec_data *ctx_data;
 
 	if (rget_io_perms())
@@ -721,10 +721,10 @@ static int ite_ec_init(const struct programmer_cfg *cfg)
 		return 1;
 	}
 
-	force_boardmismatch = ite_ec_board_mismatch_enabled(cfg);
+	force_boardmismatch_ec = ite_ec_board_mismatch_enabled(cfg);
 
 	if (!is_board_supported()) {
-		if (force_boardmismatch) {
+		if (force_boardmismatch_ec) {
 			msg_pinfo("Proceeding anyway because user forced us to.\n");
 		} else {
 			msg_pwarn("Probing on unsupported laptop may irritate your EC and cause fan failure, "


### PR DESCRIPTION
Change-Id: Ibf83be4b3c15e1a7fd9da0233dfcf79f73cbebc8

Fix for build errors